### PR TITLE
Set minimum PHP version to 7.0 ⚡

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "laravel/laravel",
-    "description": "The Laravel Framework.",
-    "keywords": ["framework", "laravel"],
+    "name": "adsa95/sirius-api",
+    "description": "The Sirius API backend.",
+    "keywords": ["sirius", "slack", "extensions"],
     "license": "MIT",
     "type": "project",
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": ">=5.6.4",
+        "php": ">=7.0.0",
         "barryvdh/laravel-cors": "^0.8.5",
         "laravel/framework": "5.4.*",
         "laravel/tinker": "~1.0"


### PR DESCRIPTION
This sets the minimum required PHP version to 7.0.0. Also includes some changes to the package information in `composer.json`.