### PR TITLE
Overall architectural changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost
 
+SIRIUS_TOKEN=null
+
 DB_CONNECTION=pgsql
 DB_HOST=127.0.0.1
 DB_PORT=5432

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,10 +1,16 @@
-<?php
+<?php namespace App\Exceptions;
 
-namespace App\Exceptions;
 
+// Core
 use Exception;
-use Illuminate\Auth\AuthenticationException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+// Helpers
+use Epoch2\HttpCodes;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -44,7 +50,7 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
-        return parent::render($request, $exception);
+        return parent::render($request, $this->wrapException($exception));
     }
 
     /**
@@ -61,5 +67,22 @@ class Handler extends ExceptionHandler
         }
 
         return redirect()->guest('login');
+    }
+
+    /*
+     * Wraps an exception in a suitable HttpException, so that the error handler
+     * can automatically return the correct response code.
+     *
+     * Defaults to HTTP 500 Internal Server Error.
+     */
+    private function wrapException(Exception $e): HttpException
+    {
+        if ($e instanceof TokenException) {
+            return new HttpException(HttpCodes::HTTP_UNAUTHORIZED, $e->getMessage(), $e);
+        } elseif ($e instanceof ModelNotFoundException) {
+            return new NotFoundHttpException($e->getMessage(), $e);
+        }
+
+        return new HttpException(HttpCodes::HTTP_INTERNAL_SERVER_ERROR, $e->getMessage(), $e);
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -81,6 +81,10 @@ class Handler extends ExceptionHandler
             return new HttpException(HttpCodes::HTTP_UNAUTHORIZED, $e->getMessage(), $e);
         } elseif ($e instanceof ModelNotFoundException) {
             return new NotFoundHttpException($e->getMessage(), $e);
+        } elseif ($e instanceof SlackException) {
+            if ($e instanceof SlackTokenException) {
+                return new HttpException(HttpCodes::HTTP_BAD_REQUEST, $e->getMessage(), $e);
+            }
         }
 
         return new HttpException(HttpCodes::HTTP_INTERNAL_SERVER_ERROR, $e->getMessage(), $e);

--- a/app/Exceptions/SlackException.php
+++ b/app/Exceptions/SlackException.php
@@ -1,8 +1,8 @@
 <?php
 namespace App\Exceptions;
 
-use \Exception;
+use \RuntimeException;
 
-class SlackException extends Exception{
-    
+class SlackException extends RuntimeException
+{
 }

--- a/app/Exceptions/SlackTokenException.php
+++ b/app/Exceptions/SlackTokenException.php
@@ -2,15 +2,6 @@
 
 namespace App\Exceptions;
 
-/**
- * Created by Johan Vester
- * johan@nicknamed.se
- *
- * Date: 2017-02-12
- *
- * (c) 2016 Nicknamed
- */
-
 class SlackTokenException extends SlackException
 {
     public static function invalidToken(): SlackTokenException

--- a/app/Exceptions/SlackTokenException.php
+++ b/app/Exceptions/SlackTokenException.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace App\Exceptions;
+
+/**
+ * Created by Johan Vester
+ * johan@nicknamed.se
+ *
+ * Date: 2017-02-12
+ *
+ * (c) 2016 Nicknamed
+ */
+
+class SlackTokenException extends SlackException
+{
+    public static function invalidToken(): SlackTokenException
+    {
+        return new static('Invalid Slack token.');
+    }
+}

--- a/app/Exceptions/TokenException.php
+++ b/app/Exceptions/TokenException.php
@@ -1,6 +1,16 @@
-<?php
-namespace App\Exceptions;
+<?php namespace App\Exceptions;
 
-class TokenException extends \Exception{
+use \RuntimeException;
 
+class TokenException extends RuntimeException
+{
+    public static function noTokenConfigured(): TokenException
+    {
+        return new static('No access token configured.');
+    }
+
+    public static function invalidToken(): TokenException
+    {
+        return new static('Invalid access token.');
+    }
 }

--- a/app/Helpers/Slack.php
+++ b/app/Helpers/Slack.php
@@ -1,7 +1,9 @@
 <?php declare(strict_types = 1);
 
 namespace App\Helpers;
-use App\Exceptions\SlackException;
+
+// Exceptions
+use App\Exceptions\SlackTokenException;
 
 class Slack
 {
@@ -12,11 +14,7 @@ class Slack
         $response = json_decode(file_get_contents($url));
 
         if (!$response->ok) {
-            throw new SlackException;
-        }
-
-        if (!array_key_exists('user_id', $response) || !array_key_exists('team_id', $response)) {
-            throw new SlackException;
+            throw SlackTokenException::invalidToken();
         }
 
         return new UserDetails($response->user_id, $response->team_id);

--- a/app/Helpers/Slack.php
+++ b/app/Helpers/Slack.php
@@ -37,6 +37,6 @@ class UserDetails
 
     public function __toString(): string
     {
-        return "$this->userId.$this->teamId";
+        return "$this->teamId.$this->userId";
     }
 }

--- a/app/Helpers/Slack.php
+++ b/app/Helpers/Slack.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace App\Helpers;
+use App\Exceptions\SlackException;
+
+class Slack
+{
+    public static function getUserDetails(string $token): UserDetails
+    {
+        return new UserDetails('abc', '123');
+        $url = "https://slack.com/api/auth.test?token=$token";
+
+        $response = json_decode(file_get_contents($url));
+
+        if (!$response->ok) {
+            throw new SlackException;
+        }
+
+        if (!array_key_exists('user_id', $response) || !array_key_exists('team_id', $response)) {
+            throw new SlackException;
+        }
+
+        return new UserDetails($response['user_id'], $response['team_id']);
+    }
+}
+
+class UserDetails
+{
+    public $userId;
+    public $teamId;
+
+    public function __construct(string $userId, string $teamId)
+    {
+        $this->userId = $userId;
+        $this->teamId = $teamId;
+    }
+
+    public function __toString(): string
+    {
+        return "$this->userId.$this->teamId";
+    }
+}

--- a/app/Helpers/Slack.php
+++ b/app/Helpers/Slack.php
@@ -7,7 +7,6 @@ class Slack
 {
     public static function getUserDetails(string $token): UserDetails
     {
-        return new UserDetails('abc', '123');
         $url = "https://slack.com/api/auth.test?token=$token";
 
         $response = json_decode(file_get_contents($url));
@@ -20,7 +19,7 @@ class Slack
             throw new SlackException;
         }
 
-        return new UserDetails($response['user_id'], $response['team_id']);
+        return new UserDetails($response->user_id, $response->team_id);
     }
 }
 

--- a/app/Http/Controllers/ConfigController.php
+++ b/app/Http/Controllers/ConfigController.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace App\Http\Controllers;
+
+// Core
+use Illuminate\Http\Request;
+
+// Helpers
+use Epoch2\HttpCodes;
+use App\Helpers\MQTT;
+use App\Helpers\Slack;
+
+// Models
+use App\Models\Config;
+
+class ConfigController extends Controller
+{
+    public function index(Request $request)
+    {
+        return response()->json(
+            Config::all(),
+            HttpCodes::HTTP_OK
+        );
+    }
+
+    public function show(Request $request, string $token)
+    {
+        return Config::where('slack_token', '=', $token)->firstOrFail();
+    }
+
+    public function store(Request $request)
+    {
+        $token = $request->input('slack_token');
+        $configConfig = $request->input('config');
+
+        $config = Config::where('slack_token', '=' , $token)->first();
+
+        if ($config !== null) {
+            $config->config = $configConfig;
+            $config->save();
+        } else {
+            // Check if the user has an existing registration with a different token
+            $id = (string) Slack::getUserDetails($token);
+
+            $config = Config::where('slack_ids', '=', $id)->first();
+
+            if ($config !== null) {
+                $oldToken = $config->slack_token;
+                $config->slack_token = $token;
+                $config->config = $configConfig;
+                $config->save();
+
+                MQTT::send("delete:{$oldToken}");
+            } else {
+                $config = new Config;
+                $config->slack_token = $token;
+                $config->slack_ids = $id;
+                $config->config = $configConfig;
+                $config->save();
+            }
+        }
+
+        MQTT::send("update:{$config->toJson()}");
+
+        return response()->json(
+            $config,
+            HttpCodes::HTTP_OK
+        );
+    }
+
+    public function destroy(Request $request, string $token)
+    {
+        $config = Config::where('slack_token', '=', $token)->firstOrFail();
+        $config->delete();
+
+        MQTT::send('delete:'.$token);
+
+        return response(null, HttpCodes::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Http/Controllers/PluginController.php
+++ b/app/Http/Controllers/PluginController.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace App\Http\Controllers;
+
+// Core
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+// Helpers
+use Epoch2\HttpCodes;
+
+// Models
+use App\Models\Plugin;
+
+class PluginController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        return response()->json(
+            Plugin::all(),
+            HttpCodes::HTTP_OK
+        );
+    }
+}

--- a/app/Http/Controllers/UpController.php
+++ b/app/Http/Controllers/UpController.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace App\Http\Controllers;
+
+// Helpers
+use Epoch2\HttpCodes;
+
+class UpController extends Controller
+{
+    public function up(Request $request)
+    {
+        return response()->json(
+            ['ok' => true],
+            HttpCodes::HTTP_OK
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "php": ">=7.0.0",
         "barryvdh/laravel-cors": "^0.8.5",
         "laravel/framework": "5.4.*",
-        "laravel/tinker": "~1.0"
+        "laravel/tinker": "~1.0",
+        "epoch2/http-codes": "^1.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "80617169c8378fa025973c32b1cdddd9",
+    "hash": "ff3a5fd653be774c7f190fc57487b3c3",
+    "content-hash": "8c778ee4b23156fa7671bc2dab01fa68",
     "packages": [
         {
             "name": "barryvdh/laravel-cors",
@@ -57,7 +58,7 @@
                 "crossdomain",
                 "laravel"
             ],
-            "time": "2017-01-25T12:53:12+00:00"
+            "time": "2017-01-25 12:53:12"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -90,7 +91,7 @@
                 "MIT"
             ],
             "description": "implementation of xdg base directory specification for php",
-            "time": "2014-10-24T07:27:01+00:00"
+            "time": "2014-10-24 07:27:01"
         },
         {
             "name": "doctrine/inflector",
@@ -157,7 +158,45 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06T14:35:42+00:00"
+            "time": "2015-11-06 14:35:42"
+        },
+        {
+            "name": "epoch2/http-codes",
+            "version": "v1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kayex/http-codes.git",
+                "reference": "c21375fd1c7a95036b68e26fccbca4b55f97de41"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kayex/http-codes/zipball/c21375fd1c7a95036b68e26fccbca4b55f97de41",
+                "reference": "c21375fd1c7a95036b68e26fccbca4b55f97de41",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Epoch2": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Johan Vester",
+                    "homepage": "http://jvester.se"
+                }
+            ],
+            "description": "Small PHP library for easily accessing HTTP Status Codes.",
+            "keywords": [
+                "http",
+                "http code",
+                "http status"
+            ],
+            "time": "2015-06-04 12:14:17"
         },
         {
             "name": "erusev/parsedown",
@@ -199,7 +238,7 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2016-11-02T15:56:58+00:00"
+            "time": "2016-11-02 15:56:58"
         },
         {
             "name": "jakub-onderka/php-console-color",
@@ -242,7 +281,7 @@
                     "homepage": "http://www.acci.cz"
                 }
             ],
-            "time": "2014-04-08T15:00:19+00:00"
+            "time": "2014-04-08 15:00:19"
         },
         {
             "name": "jakub-onderka/php-console-highlighter",
@@ -286,7 +325,7 @@
                     "homepage": "http://www.acci.cz/"
                 }
             ],
-            "time": "2015-04-20T18:58:01+00:00"
+            "time": "2015-04-20 18:58:01"
         },
         {
             "name": "laravel/framework",
@@ -415,7 +454,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2017-02-10T19:40:54+00:00"
+            "time": "2017-02-10 19:40:54"
         },
         {
             "name": "laravel/tinker",
@@ -473,7 +512,7 @@
                 "laravel",
                 "psysh"
             ],
-            "time": "2016-12-30T18:13:17+00:00"
+            "time": "2016-12-30 18:13:17"
         },
         {
             "name": "league/flysystem",
@@ -556,7 +595,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2017-02-09T11:33:58+00:00"
+            "time": "2017-02-09 11:33:58"
         },
         {
             "name": "monolog/monolog",
@@ -634,7 +673,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2016-11-26T00:15:39+00:00"
+            "time": "2016-11-26 00:15:39"
         },
         {
             "name": "mtdowling/cron-expression",
@@ -678,7 +717,7 @@
                 "cron",
                 "schedule"
             ],
-            "time": "2017-01-23T04:29:33+00:00"
+            "time": "2017-01-23 04:29:33"
         },
         {
             "name": "nesbot/carbon",
@@ -731,7 +770,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2017-01-16T07:55:07+00:00"
+            "time": "2017-01-16 07:55:07"
         },
         {
             "name": "nikic/php-parser",
@@ -782,7 +821,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2017-02-10T20:20:03+00:00"
+            "time": "2017-02-10 20:20:03"
         },
         {
             "name": "paragonie/random_compat",
@@ -830,7 +869,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-11-07T23:38:38+00:00"
+            "time": "2016-11-07 23:38:38"
         },
         {
             "name": "psr/log",
@@ -877,7 +916,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "psy/psysh",
@@ -950,7 +989,7 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2017-01-15T17:54:13+00:00"
+            "time": "2017-01-15 17:54:13"
         },
         {
             "name": "ramsey/uuid",
@@ -1032,7 +1071,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2016-11-22T19:21:44+00:00"
+            "time": "2016-11-22 19:21:44"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -1086,7 +1125,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2016-12-29T10:02:40+00:00"
+            "time": "2016-12-29 10:02:40"
         },
         {
             "name": "symfony/console",
@@ -1149,7 +1188,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-06T12:04:21+00:00"
+            "time": "2017-02-06 12:04:21"
         },
         {
             "name": "symfony/css-selector",
@@ -1202,7 +1241,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02T20:32:22+00:00"
+            "time": "2017-01-02 20:32:22"
         },
         {
             "name": "symfony/debug",
@@ -1259,7 +1298,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-28T02:37:08+00:00"
+            "time": "2017-01-28 02:37:08"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1319,7 +1358,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02T20:32:22+00:00"
+            "time": "2017-01-02 20:32:22"
         },
         {
             "name": "symfony/finder",
@@ -1368,7 +1407,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02T20:32:22+00:00"
+            "time": "2017-01-02 20:32:22"
         },
         {
             "name": "symfony/http-foundation",
@@ -1421,7 +1460,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-02T13:47:35+00:00"
+            "time": "2017-02-02 13:47:35"
         },
         {
             "name": "symfony/http-kernel",
@@ -1503,7 +1542,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-06T13:15:19+00:00"
+            "time": "2017-02-06 13:15:19"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1562,7 +1601,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/process",
@@ -1611,7 +1650,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-03T12:11:38+00:00"
+            "time": "2017-02-03 12:11:38"
         },
         {
             "name": "symfony/routing",
@@ -1686,7 +1725,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-01-28T02:37:08+00:00"
+            "time": "2017-01-28 02:37:08"
         },
         {
             "name": "symfony/translation",
@@ -1750,7 +1789,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21T17:06:35+00:00"
+            "time": "2017-01-21 17:06:35"
         },
         {
             "name": "symfony/var-dumper",
@@ -1813,7 +1852,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2017-01-24T12:58:58+00:00"
+            "time": "2017-01-24 12:58:58"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -1860,7 +1899,7 @@
             ],
             "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
             "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
-            "time": "2016-09-20T12:50:39+00:00"
+            "time": "2016-09-20 12:50:39"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -1910,7 +1949,7 @@
                 "env",
                 "environment"
             ],
-            "time": "2016-09-01T10:05:43+00:00"
+            "time": "2016-09-01 10:05:43"
         }
     ],
     "packages-dev": [
@@ -1966,7 +2005,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2015-06-14 21:17:01"
         },
         {
             "name": "fzaninotto/faker",
@@ -2014,7 +2053,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2016-04-29T12:21:54+00:00"
+            "time": "2016-04-29 12:21:54"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -2059,7 +2098,7 @@
             "keywords": [
                 "test"
             ],
-            "time": "2015-05-11T14:41:42+00:00"
+            "time": "2015-05-11 14:41:42"
         },
         {
             "name": "mockery/mockery",
@@ -2124,7 +2163,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2017-02-09T13:29:38+00:00"
+            "time": "2017-02-09 13:29:38"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2166,7 +2205,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-01-26T22:05:40+00:00"
+            "time": "2017-01-26 22:05:40"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2220,7 +2259,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2015-12-27 11:43:31"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -2265,7 +2304,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2016-09-30 07:12:33"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2312,7 +2351,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2016-11-25 06:54:22"
         },
         {
             "name": "phpspec/prophecy",
@@ -2375,7 +2414,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21T14:58:47+00:00"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2438,7 +2477,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-01-20T15:06:43+00:00"
+            "time": "2017-01-20 15:06:43"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2485,7 +2524,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2526,7 +2565,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
@@ -2570,7 +2609,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12T18:03:57+00:00"
+            "time": "2016-05-12 18:03:57"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -2619,7 +2658,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15T14:06:22+00:00"
+            "time": "2016-11-15 14:06:22"
         },
         {
             "name": "phpunit/phpunit",
@@ -2701,7 +2740,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-10T09:05:10+00:00"
+            "time": "2017-02-10 09:05:10"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -2760,7 +2799,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-12-08T20:27:08+00:00"
+            "time": "2016-12-08 20:27:08"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2805,7 +2844,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13T06:45:14+00:00"
+            "time": "2016-02-13 06:45:14"
         },
         {
             "name": "sebastian/comparator",
@@ -2869,7 +2908,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2017-01-29 09:50:25"
         },
         {
             "name": "sebastian/diff",
@@ -2921,7 +2960,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2015-12-08 07:14:41"
         },
         {
             "name": "sebastian/environment",
@@ -2971,7 +3010,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2016-11-26 07:53:53"
         },
         {
             "name": "sebastian/exporter",
@@ -3038,7 +3077,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2016-11-19 08:54:04"
         },
         {
             "name": "sebastian/global-state",
@@ -3089,7 +3128,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2015-10-12 03:26:01"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -3135,7 +3174,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-11-19T07:35:10+00:00"
+            "time": "2016-11-19 07:35:10"
         },
         {
             "name": "sebastian/recursion-context",
@@ -3188,7 +3227,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2016-11-19 07:33:16"
         },
         {
             "name": "sebastian/resource-operations",
@@ -3230,7 +3269,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2015-07-28 20:34:47"
         },
         {
             "name": "sebastian/version",
@@ -3273,7 +3312,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "time": "2016-10-03 07:35:21"
         },
         {
             "name": "symfony/yaml",
@@ -3328,7 +3367,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21T17:06:35+00:00"
+            "time": "2017-01-21 17:06:35"
         },
         {
             "name": "webmozart/assert",
@@ -3378,7 +3417,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2016-11-23 20:04:58"
         }
     ],
     "aliases": [],

--- a/config/access.php
+++ b/config/access.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'token' => env('SIRIUS_TOKEN', null),
+];

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,25 @@
 <?php
 
+$databaseUrl = env('DATABASE_URL');
+
+$urlDb = [
+    'host' => null,
+    'port' => null,
+    'database' => null,
+    'username' => null,
+    'password' => null
+];
+
+if ($databaseUrl !== null) {
+    $parsed = parse_url($url);
+
+    $urlDb['host'] = $parsed['host'];
+    $urlDb['port'] = $parsed['port'];
+    $urlDb['username'] = $parsed['user'];
+    $urlDb['password'] = $parsed['pass'];
+    $urlDb['database'] = substr($parsed['path'], 1);
+}
+
 return [
 
     /*
@@ -68,11 +88,11 @@ return [
 
         'heroku' => [
             'driver' => 'pgsql',
-            'host' => env('DB_HOST', parse_url(getenv("DATABASE_URL"))['host']),
-            'port' => env('DB_PORT', '5432'),
-            'database' => env('DB_DATABASE', substr(parse_url(getenv("DATABASE_URL"))['path'], 1)),
-            'username' => env('DB_USERNAME', parse_url(getenv("DATABASE_URL"))['user']),
-            'password' => env('DB_PASSWORD', parse_url(getenv("DATABASE_URL"))['pass']),
+            'host' => $urlDb['host'],
+            'port' => $urlDb['port'],
+            'database' => $urlDb['database'],
+            'username' => $urlDb['username'],
+            'password' => $urlDb['password'],
             'charset' => 'utf8',
             'prefix' => '',
             'schema' => 'public',

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,54 +28,9 @@ Route::get('/up', function (Request $request) {
     return '{"ok": true}';
 });
 
-Route::get('/plugins', function(Request $request){
-	return Plugin::all();
-});
+Route::get('/plugins', 'PluginController@index');
+Route::get('/configs', 'ConfigController@index')->middleware(['require.token']);
+Route::get('/configs/{token}', 'ConfigController@show');
+Route::post('/configs', 'ConfigController@store');
+Route::delete('/configs/{token}', 'ConfigController@destroy');
 
-Route::get('/configs', function(Request $request){
-    return Config::all();
-})->middleware(['require.token']);
-
-Route::get('/configs/{token}', function(Request $request, $token){
-	return Config::where('slack_token', '=', $token)->firstOrFail();
-});
-
-Route::delete('/configs/{token}', function(Request $request, $token){
-	$config = Config::where('slack_token', '=', $token)->firstOrFail();
-	$config->destroy();
-	MQTT::send('delete:'.$token);
-});
-
-Route::post('/configs', function(Request $request){
-	$data = $request->all();
-
-	$model = Config::where('slack_token', '=' , $data['slack_token'])->first();
-
-	if($model == null){
-		$slackData = json_decode(file_get_contents('https://slack.com/api/auth.test?token='.$data['slack_token']));
-		if($slackData->ok == false){
-			throw new SlackException;
-		}
-
-		$slack_ids = $slackData->team_id.'.'.$slackData->user_id;
-		$model = Config::where('slack_ids', '=', $slack_ids)->first();
-
-		if($model !== null){
-			//slack token is valid, user config exists but with another token, deregister the old one with the sirius-server
-			MQTT::send('delete:'.$model->slack_token);
-		}
-	}
-
-	if($model == null){
-		$model = new Config;
-		$model->slack_token = $data['slack_token'];
-		$model->slack_ids = $slack_ids;
-	}
-
-	$model->config = $data['config'];
-
-	$model->save();
-	MQTT::send('update:'.$model->toJson());
-
-	return $model->fresh();
-});

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,9 +24,7 @@ use App\Models\Config;
 |
 */
 
-Route::get('/up', function (Request $request) {
-    return '{"ok": true}';
-});
+Route::get('/up', 'UpController@up');
 
 Route::get('/plugins', 'PluginController@index');
 Route::get('/configs', 'ConfigController@index')->middleware(['require.token']);


### PR DESCRIPTION
This is a slightly bigger pull request that tackles a few things:

### Move application logic out of `routes/`
This allows the `php artisan route:cache` command to be used, which will generate static route files that are faster than executing route bindings at runtime.

### Move Slack API communication into helper
The API call to fetch a user's `$userId` and `$teamId` has been refactored into a separate class. Additionally, the unique combination of user and team ID is now represented internally with the `UserDetails` class. It's easily converted into the concatenated format (`{team}.{user}`) by being cast to `string`.

### Wait with notifying Sirius until changes are flushed to DB
The MQTT publishes are now only done after any config changes have successfully been written to storage. This is to prevent inconsistencies between configs returned by `sirius-api` and configs running live in `sirius` in case of a write failure.

### Specific HTTP error codes
The following exceptions have been mapped to HTTP status codes:

| Exception | Status code |
| :--- | :--- |
|`TokenException`|`401 Unauthorized`|
|`ModelNotFoundException`|`404 Not Found`|
|`SlackTokenException`|`400 Bad Request`|