### PR TITLE
Console command for removing plugin

### DIFF
--- a/app/Console/Commands/AddPlugin.php
+++ b/app/Console/Commands/AddPlugin.php
@@ -13,7 +13,7 @@ class AddPlugin extends Command
      *
      * @var string
      */
-    protected $signature = 'add:plugin {name} {description}';
+    protected $signature = 'plugin:add {name} {description}';
 
     /**
      * The console command description.

--- a/app/Console/Commands/RemovePlugin.php
+++ b/app/Console/Commands/RemovePlugin.php
@@ -13,7 +13,7 @@ class RemovePlugin extends Command
      *
      * @var string
      */
-    protected $signature = 'remove:plugin {name}';
+    protected $signature = 'plugin:remove {name}';
 
     /**
      * The console command description.

--- a/app/Console/Commands/RemovePlugin.php
+++ b/app/Console/Commands/RemovePlugin.php
@@ -1,0 +1,46 @@
+<?php namespace App\Console\Commands;
+
+// Core
+use Illuminate\Console\Command;
+
+// Models
+use App\Models\Plugin;
+
+class RemovePlugin extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'remove:plugin {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove a plugin';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $name = $this->argument('name');
+        $plugin = Plugin::where('name', '=', $name);
+        $plugin->delete();
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,8 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        Commands\AddPlugin::class
+        Commands\AddPlugin::class,
+        Commands\RemovePlugin::class
     ];
 
     /**


### PR DESCRIPTION
Adds a console command for removing a plugin. I moved this command together with the `add:plugin` command into the `plugin` namespace, which makes them show up next to each other when you run `php artisan list`:
![screen shot 2017-02-13 at 11 05 00](https://cloud.githubusercontent.com/assets/1407203/22879034/5dc91a80-f1dc-11e6-9ec9-d23fa6414d5d.png)
