### PR TITLE
Use SHA-256 ID instead of token 🔒

### DIFF
--- a/app/Http/Controllers/ConfigController.php
+++ b/app/Http/Controllers/ConfigController.php
@@ -32,10 +32,10 @@ class ConfigController extends Controller
         );
     }
 
-    public function show(Request $request, string $token)
+    public function show(Request $request, string $siriusId)
     {
         return response()->json(
-            Config::where('slack_token', '=', $token)->firstOrFail(),
+            Config::where('sirius_id', '=', $siriusId)->firstOrFail(),
             HttpCodes::HTTP_OK
         );
     }
@@ -83,12 +83,12 @@ class ConfigController extends Controller
         );
     }
 
-    public function destroy(Request $request, string $token)
+    public function destroy(Request $request, string $siriusId)
     {
-        $config = Config::where('slack_token', '=', $token)->firstOrFail();
+        $config = Config::where('sirius_id', '=', $siriusId)->firstOrFail();
         $config->delete();
 
-        $this->notifier->delete($token);
+        $this->notifier->delete($siriusId);
 
         return response(null, HttpCodes::HTTP_NO_CONTENT);
     }

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -7,12 +7,6 @@ class Config extends Model
 {
     protected $fillable = ['config', 'slack_token'];
     protected $hidden = ['slack_ids'];
-    protected $appends = ['id_hash_sha256'];
-
-    public function getIdHashSha256Attribute()
-    {
-        return hash('sha256', $this->attributes['slack_ids']);
-    }
 
     public function getConfigAttribute($value)
     {

--- a/app/Observers/ConfigObserver.php
+++ b/app/Observers/ConfigObserver.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace App\Observers;
+
+// Models
+use App\Models\Config;
+
+class ConfigObserver
+{
+    public function saving(Config $config)
+    {
+        if ($config->sirius_id === null) {
+            $config->sirius_id = hash('sha256', $config->slack_ids);
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,14 @@
 
 namespace App\Providers;
 
+// Core
 use Illuminate\Support\ServiceProvider;
+
+// Observers
+use App\Observers\ConfigObserver;
+
+// Models
+use App\Models\Config;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,7 +20,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Config::observe(ConfigObserver::class);
     }
 
     /**

--- a/app/Services/MQTTNotifier.php
+++ b/app/Services/MQTTNotifier.php
@@ -21,16 +21,16 @@ class MQTTNotifier implements Notifier
 
     public function new(Config $config)
     {
-        $this->client->publish($this->topic, "new:{$config->slack_token}");
+        $this->client->publish($this->topic, "new:{$config->sirius_id}");
     }
 
     public function update(Config $config)
     {
-        $this->client->publish($this->topic, "update:{$config->slack_token}");
+        $this->client->publish($this->topic, "update:{$config->sirius_id}");
     }
 
-    public function delete(string $token)
+    public function delete(string $id)
     {
-        $this->client->publish($this->topic, "delete:{$token}");
+        $this->client->publish($this->topic, "delete:{$id}");
     }
 }

--- a/app/Services/Notifier.php
+++ b/app/Services/Notifier.php
@@ -14,5 +14,5 @@ interface Notifier
 {
     public function new(Config $config);
     public function update(Config $config);
-    public function delete(string $token);
+    public function delete(string $id);
 }

--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,10 @@
     "require": {
         "php": ">=7.0.0",
         "barryvdh/laravel-cors": "^0.8.5",
+        "doctrine/dbal": "^2.5",
+        "epoch2/http-codes": "^1.0",
         "laravel/framework": "5.4.*",
-        "laravel/tinker": "~1.0",
-        "epoch2/http-codes": "^1.0"
+        "laravel/tinker": "~1.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ff3a5fd653be774c7f190fc57487b3c3",
-    "content-hash": "8c778ee4b23156fa7671bc2dab01fa68",
+    "hash": "b2ef6b2e849a2ed4ee63a79658468698",
+    "content-hash": "911a7fc61d68899bf434e2bf90fb975f",
     "packages": [
         {
             "name": "barryvdh/laravel-cors",
@@ -94,6 +94,355 @@
             "time": "2014-10-24 07:27:01"
         },
         {
+            "name": "doctrine/annotations",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "bd4461328621bde0ae6b1b2675fbc6aca4ceb558"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/bd4461328621bde0ae6b1b2675fbc6aca4ceb558",
+                "reference": "bd4461328621bde0ae6b1b2675fbc6aca4ceb558",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^5.6.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2016-12-30 15:59:45"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/b6f544a20f4807e81f7044d31e679ccbb1866dc3",
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.5|~7.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8|~5.0",
+                "predis/predis": "~1.0",
+                "satooshi/php-coveralls": "~0.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2016-10-29 11:16:17"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2017-01-03 10:49:41"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "930297026c8009a567ac051fd545bf6124150347"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/930297026c8009a567ac051fd545bf6124150347",
+                "reference": "930297026c8009a567ac051fd545bf6124150347",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": "~5.6|~7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2017-01-13 14:02:13"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.5.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "7b9e911f9d8b30d43b96853dab26898c710d8f44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/7b9e911f9d8b30d43b96853dab26898c710d8f44",
+                "reference": "7b9e911f9d8b30d43b96853dab26898c710d8f44",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": ">=2.4,<2.8-dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*",
+                "symfony/console": "2.*||^3.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2017-02-08 12:53:47"
+        },
+        {
             "name": "doctrine/inflector",
             "version": "v1.1.0",
             "source": {
@@ -159,6 +508,60 @@
                 "string"
             ],
             "time": "2015-11-06 14:35:42"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09 13:34:57"
         },
         {
             "name": "epoch2/http-codes",

--- a/database/migrations/2017_02_13_185650_create_sirius_id_column.php
+++ b/database/migrations/2017_02_13_185650_create_sirius_id_column.php
@@ -27,6 +27,11 @@ class CreateSiriusIdColumn extends Migration
                 ]);
             }
         }
+
+        // Add NOT NULL
+        Schema::table('configs', function (Blueprint $table) {
+            $table->string('sirius_id', 64)->nullable(false)->change();
+        });
     }
 
     /**

--- a/database/migrations/2017_02_13_185650_create_sirius_id_column.php
+++ b/database/migrations/2017_02_13_185650_create_sirius_id_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateSiriusIdColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('configs', function (Blueprint $table) {
+            $table->string('sirius_id', 64)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('configs', function (Blueprint $table) {
+            $table->dropColumn('sirius_id');
+        });
+    }
+}

--- a/database/migrations/2017_02_13_185650_create_sirius_id_column.php
+++ b/database/migrations/2017_02_13_185650_create_sirius_id_column.php
@@ -16,6 +16,17 @@ class CreateSiriusIdColumn extends Migration
         Schema::table('configs', function (Blueprint $table) {
             $table->string('sirius_id', 64)->nullable();
         });
+
+        // Generate ID for existing configs
+        $configs = DB::table('configs')->select('id', 'slack_ids', 'sirius_id')->get();
+
+        foreach ($configs as $config) {
+            if ($config->sirius_id === null) {
+                DB::table('configs')->where('id', $config->id)->update([
+                    'sirius_id' => hash('sha256', $config->slack_ids)
+                ]);
+            }
+        }
     }
 
     /**

--- a/readme.md
+++ b/readme.md
@@ -22,8 +22,8 @@ This method saves or updates an existing config. The request body should be a JS
 ```
 The API decides when to save a new and when to update a configuration, the database is searched for the specific Slack token, and if not found, it also uses the Slack API to get the user team and user id and compare those with what's already in the database. This is to avoid dublicate entries for the same user but with different tokens.
 
-### GET /configs/{slack_token}
-This method returns the configuration for a specific token.
+### GET /configs/{sirius_id}
+This method returns the configuration for a specific sirius_id.
 
-### DELETE /configs/{slack_token}
-This method deletes the configuration with a specific slack_token.
+### DELETE /configs/{sirius_id}
+This method deletes the configuration with a specific sirius_id.

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,7 +28,7 @@ Route::get('/up', 'UpController@up');
 
 Route::get('/plugins', 'PluginController@index');
 Route::get('/configs', 'ConfigController@index')->middleware(['require.token']);
-Route::get('/configs/{token}', 'ConfigController@show');
+Route::get('/configs/{sirius_id}', 'ConfigController@show');
 Route::post('/configs', 'ConfigController@store');
-Route::delete('/configs/{token}', 'ConfigController@destroy');
+Route::delete('/configs/{sirius_id}', 'ConfigController@destroy');
 


### PR DESCRIPTION
Changed all usages of `token` as a config identifier to the sha256 sum of the `TeamID` and `UserID` concatenated with a single period (`.`). This hash sum is referred to as `sirius_id`.

The following endpoints have been affected
* `GET /configs/{sirius_id}`
* `DELETE /configs/{sirius_id}`

as well as the MQTT `NEW`, `DELETE` and `UPDATE` notifications.