### PR TITLE
Use {} instead of [] for unconfigured extensions in config JSON

### DIFF
--- a/app/Http/Controllers/ConfigController.php
+++ b/app/Http/Controllers/ConfigController.php
@@ -6,7 +6,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 
 // Helpers
-use Epoch2\HttpCodes;
+use Kayex\HttpCodes;
 use App\Helpers\Slack;
 
 // Services

--- a/app/Http/Controllers/PluginController.php
+++ b/app/Http/Controllers/PluginController.php
@@ -6,7 +6,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 
 // Helpers
-use Epoch2\HttpCodes;
+use Kayex\HttpCodes;
 
 // Models
 use App\Models\Plugin;

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -7,33 +7,35 @@ class Config extends Model
 {
     protected $fillable = ['config', 'slack_token', 'http_extensions'];
     protected $hidden = ['slack_ids', 'id'];
+    protected $casts = [
+        'config' => 'object',
+        'http_extensions' => 'object',
+    ];
 
     public function httpPlugins()
     {
-        return $this->hasMany('App\Models\HttpPlugin', 'sirius_id', 'sirius_id');
+        return $this->hasMany(App\Models\HttpPlugin::class, 'sirius_id', 'sirius_id');
     }
 
-    public function getConfigAttribute($value)
+    public function setConfigAttribute(array $config)
     {
-        if ($value === null) return $value;
+        foreach ($config as $extension => &$settings) {
 
-        return json_decode($value);
+            if (empty($settings)) {
+                $settings = json_decode('{}', false);
+            }
+        }
     }
 
-    public function setConfigAttribute($value)
+    public function setHttpExtensionsAttribute(array $config)
     {
-        $this->attributes['config'] = json_encode($value);
-    }
+        foreach ($config as $extension => &$settings) {
 
-    public function getHttpExtensionsAttribute($value)
-    {
-        if ($value === null) return $value;
+            if (empty($settings)) {
+                $settings = json_decode('{}', false);
+            }
+        }
 
-        return json_decode($value);
-    }
-
-    public function setHttpExtensionsAttribute($value)
-    {   
-        $this->attributes['http_extensions'] = json_encode($value);
+        $this->attributes['http_extensions'] = json_encode($config);
     }
 }

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -19,23 +19,35 @@ class Config extends Model
 
     public function setConfigAttribute(array $config)
     {
-        foreach ($config as $extension => &$settings) {
+        $encoded = json_encode($this->emptyArraysToObjects($config), false);
 
-            if (empty($settings)) {
-                $settings = json_decode('{}', false);
-            }
-        }
+        $this->attributes['config'] = $encoded;
     }
 
     public function setHttpExtensionsAttribute(array $config)
     {
-        foreach ($config as $extension => &$settings) {
+        $encoded = json_encode($this->emptyArraysToObjects($config), false);
 
-            if (empty($settings)) {
-                $settings = json_decode('{}', false);
+        $this->attributes['http_extensions'] = $encoded;
+    }
+
+    public function emptyArraysToObjects(array $json)
+    {
+        if (empty($json)) {
+            return $this->emptyJsonObject();
+        }
+
+        foreach ($json as $key => &$value) {
+            if (is_array($value) && empty($value)) {
+                $value = $this->emptyJsonObject();
             }
         }
 
-        $this->attributes['http_extensions'] = json_encode($config);
+        return $json;
+    }
+
+    public function emptyJsonObject()
+    {
+        return json_decode('{}', false);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=7.0.0",
         "barryvdh/laravel-cors": "^0.8.5",
         "doctrine/dbal": "^2.5",
-        "epoch2/http-codes": "^1.0",
+        "kayex/http-codes": "^1.0",
         "laravel/framework": "5.4.*",
         "laravel/tinker": "~1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -694,22 +694,22 @@
         },
         {
             "name": "kayex/http-codes",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kayex/http-codes.git",
-                "reference": "9434bbf7e6f46da74bb81df9851855dcf77ade31"
+                "reference": "4f7f8967d539f670b6b2dfdb86ad02de3d60e7b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kayex/http-codes/zipball/9434bbf7e6f46da74bb81df9851855dcf77ade31",
-                "reference": "9434bbf7e6f46da74bb81df9851855dcf77ade31",
+                "url": "https://api.github.com/repos/kayex/http-codes/zipball/4f7f8967d539f670b6b2dfdb86ad02de3d60e7b5",
+                "reference": "4f7f8967d539f670b6b2dfdb86ad02de3d60e7b5",
                 "shasum": ""
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "Kayex": "src/"
+                "psr-4": {
+                    "Kayex\\": "src/Kayex/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -725,10 +725,10 @@
             "description": "Small PHP library for easily accessing HTTP Status Codes.",
             "keywords": [
                 "http",
-                "http code",
-                "http status"
+                "http status",
+                "status code"
             ],
-            "time": "2017-02-14 13:29:27"
+            "time": "2017-02-14 13:50:37"
         },
         {
             "name": "laravel/framework",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b2ef6b2e849a2ed4ee63a79658468698",
-    "content-hash": "911a7fc61d68899bf434e2bf90fb975f",
+    "hash": "a6d4351e000d6038b50ea5fe2727844b",
+    "content-hash": "ed95fa401f4678d60c9ad76b9fbda691",
     "packages": [
         {
             "name": "barryvdh/laravel-cors",
@@ -564,44 +564,6 @@
             "time": "2014-09-09 13:34:57"
         },
         {
-            "name": "epoch2/http-codes",
-            "version": "v1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kayex/http-codes.git",
-                "reference": "c21375fd1c7a95036b68e26fccbca4b55f97de41"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kayex/http-codes/zipball/c21375fd1c7a95036b68e26fccbca4b55f97de41",
-                "reference": "c21375fd1c7a95036b68e26fccbca4b55f97de41",
-                "shasum": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Epoch2": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Johan Vester",
-                    "homepage": "http://jvester.se"
-                }
-            ],
-            "description": "Small PHP library for easily accessing HTTP Status Codes.",
-            "keywords": [
-                "http",
-                "http code",
-                "http status"
-            ],
-            "time": "2015-06-04 12:14:17"
-        },
-        {
             "name": "erusev/parsedown",
             "version": "1.6.1",
             "source": {
@@ -729,6 +691,44 @@
                 }
             ],
             "time": "2015-04-20 18:58:01"
+        },
+        {
+            "name": "kayex/http-codes",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kayex/http-codes.git",
+                "reference": "9434bbf7e6f46da74bb81df9851855dcf77ade31"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kayex/http-codes/zipball/9434bbf7e6f46da74bb81df9851855dcf77ade31",
+                "reference": "9434bbf7e6f46da74bb81df9851855dcf77ade31",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Kayex": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Johan Vester",
+                    "homepage": "http://jvester.se"
+                }
+            ],
+            "description": "Small PHP library for easily accessing HTTP Status Codes.",
+            "keywords": [
+                "http",
+                "http code",
+                "http status"
+            ],
+            "time": "2017-02-14 13:29:27"
         },
         {
             "name": "laravel/framework",

--- a/database/migrations/2017_03_07_103449_update_http_extensions_default_value.php
+++ b/database/migrations/2017_03_07_103449_update_http_extensions_default_value.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateHttpExtensionsDefaultValue extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Using $table->change() won't work here, as the Doctrine DBAL
+        // that is responsible for modifying columns cannot detect
+        // the database type automatically, and therefore refuses to touch
+        // columns of the 'json' type.
+        //
+        // We'll work around this by dropping the column and adding it again
+        // with the proper default value.
+
+        // Make sure we don't lose any extensions
+        $configs = DB::table('configs')->select('id', 'http_extensions')->get();
+
+        Schema::table('configs', function (Blueprint $table) {
+            $table->dropColumn('http_extensions');
+        });
+
+        Schema::table('configs', function (Blueprint $table) {
+            $table->json('http_extensions')->default('{}');
+        });
+
+        foreach ($configs as $config) {
+            if ($config->http_extensions === '[]') {
+                $config->http_extensions = '{}';
+            }
+
+            DB::table('configs')->where('id', $config->id)->update([
+                'http_extensions' => $config->http_extensions,
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $configs = DB::table('configs')->select('id', 'http_extensions')->get();
+
+        Schema::table('configs', function (Blueprint $table) {
+            $table->dropColumn('http_extensions');
+        });
+
+        Schema::table('configs', function (Blueprint $table) {
+            $table->json('http_extensions')->default('[]');
+        });
+
+        foreach ($configs as $config) {
+            if ($config->http_extensions === '{}') {
+                $config->http_extensions = '[]';
+            }
+
+            DB::table('configs')->where('id', $config->id)->update([
+                'http_extensions' => $config->http_extensions,
+            ]);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,18 +1,5 @@
 <?php
 
-// Core
-use Illuminate\Http\Request;
-
-// Exceptions
-use App\Exceptions\SlackException;
-
-// MQTT
-use App\Helpers\MQTT;
-
-// Models
-use App\Models\Plugin;
-use App\Models\Config;
-
 /*
 |--------------------------------------------------------------------------
 | API Routes


### PR DESCRIPTION
This changes the JSON representation of empty configurations and empty extension configurations (empty array values in `config` object) from `[]` (empty JSON array) to `{}` (empty JSON object).

Includes the same change for the `http_extensions` field.

Example of the new JSON structure, with both `http_extensions` and the config for `geocode` being empty:
```javascript
{
  "slack_token": "xoxp-14643781812-14649325041-141056050630-cbc6c2397168e9f2506a5be843216471",
  "config": {
    "geocode": {} // Previously []
  },
  "created_at": "2017-03-07 11:20:09",
  "updated_at": "2017-03-07 11:30:50",
  "sirius_id": "69f310caad7f2f7422f65d7188668d95047f4e66253dc59b99b71f44ab5b6b91",
  "http_extensions": {} // Previously []
}
```
I did not test this with sirius-web, but I don't think any changes will be needed there.

## Misc
* Updated kayex/http-codes
* Some clean-up