### PR TITLE
Use kayex/http-codes everywhere

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -9,7 +9,7 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 // Helpers
-use Epoch2\HttpCodes;
+use Kayex\HttpCodes;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Handler extends ExceptionHandler

--- a/app/Http/Controllers/HttpPluginController.php
+++ b/app/Http/Controllers/HttpPluginController.php
@@ -6,7 +6,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 
 // Helpers
-use Epoch2\HttpCodes;
+use Kayex\HttpCodes;
 
 // Models
 use App\Models\HttpPlugin;

--- a/app/Http/Controllers/UpController.php
+++ b/app/Http/Controllers/UpController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 // Helpers
-use Epoch2\HttpCodes;
+use Kayex\HttpCodes;
 
 class UpController extends Controller
 {


### PR DESCRIPTION
Replaces `Epoch2\HttpCodes` (deprecated) with `Kayex\HttpCodes`.