### PR TITLE
Update kayex/http-codes to 1.0.5

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -694,22 +694,22 @@
         },
         {
             "name": "kayex/http-codes",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kayex/http-codes.git",
-                "reference": "4f7f8967d539f670b6b2dfdb86ad02de3d60e7b5"
+                "reference": "68a80b7862382f90aefb7b2e6523436713138cd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kayex/http-codes/zipball/4f7f8967d539f670b6b2dfdb86ad02de3d60e7b5",
-                "reference": "4f7f8967d539f670b6b2dfdb86ad02de3d60e7b5",
+                "url": "https://api.github.com/repos/kayex/http-codes/zipball/68a80b7862382f90aefb7b2e6523436713138cd8",
+                "reference": "68a80b7862382f90aefb7b2e6523436713138cd8",
                 "shasum": ""
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Kayex\\": "src/Kayex/"
+                    "Kayex\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -728,7 +728,7 @@
                 "http status",
                 "status code"
             ],
-            "time": "2017-02-14 13:50:37"
+            "time": "2017-02-21 13:23:59"
         },
         {
             "name": "laravel/framework",


### PR DESCRIPTION
Updates kayex/http-codes to version `1.0.5`. `1.0.4` has some quite severe compatibility issues with composer's autoloader, so this should probably be merged ASAP.