### PR TITLE
Rename Plugin to Extension

### DIFF
--- a/app/Console/Commands/AddExtension.php
+++ b/app/Console/Commands/AddExtension.php
@@ -4,23 +4,23 @@
 use Illuminate\Console\Command;
 
 // Models
-use App\Models\Plugin;
+use App\Models\Extension;
 
-class RemovePlugin extends Command
+class AddExtension extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'plugin:remove {name}';
+    protected $signature = 'extension:add {name} {description}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Remove a plugin';
+    protected $description = 'Add an extension to the database';
 
     /**
      * Create a new command instance.
@@ -39,8 +39,9 @@ class RemovePlugin extends Command
      */
     public function handle()
     {
-        $name = $this->argument('name');
-        $plugin = Plugin::where('name', '=', $name);
-        $plugin->delete();
+        $extension = new Extension();
+        $extension->name = $this->argument('name');
+        $extension->description = $this->argument('description');
+        $extension->save();
     }
 }

--- a/app/Console/Commands/RemoveExtension.php
+++ b/app/Console/Commands/RemoveExtension.php
@@ -4,23 +4,23 @@
 use Illuminate\Console\Command;
 
 // Models
-use App\Models\Plugin;
+use App\Models\Extension;
 
-class AddPlugin extends Command
+class RemoveExtension extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'plugin:add {name} {description}';
+    protected $signature = 'extension:remove {name}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Add a plugin to the database';
+    protected $description = 'Remove an extension by its EID';
 
     /**
      * Create a new command instance.
@@ -39,9 +39,8 @@ class AddPlugin extends Command
      */
     public function handle()
     {
-        $plugin = new Plugin;
-        $plugin->name = $this->argument('name');
-        $plugin->description = $this->argument('description');
-        $plugin->save();
+        $name = $this->argument('name');
+        $extension = Extension::where('name', '=', $name);
+        $extension->delete();
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,8 +13,8 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        Commands\AddPlugin::class,
-        Commands\RemovePlugin::class
+        Commands\AddExtension::class,
+        Commands\RemoveExtension::class
     ];
 
     /**

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -10,7 +10,6 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 // Helpers
 use Kayex\HttpCodes;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class Handler extends ExceptionHandler
 {
@@ -77,10 +76,14 @@ class Handler extends ExceptionHandler
      */
     private function wrapException(Exception $e): HttpException
     {
+        if ($e instanceof HttpException) {
+            return $e;
+        }
+
         if ($e instanceof TokenException) {
             return new HttpException(HttpCodes::HTTP_UNAUTHORIZED, $e->getMessage(), $e);
         } elseif ($e instanceof ModelNotFoundException) {
-            return new NotFoundHttpException($e->getMessage(), $e);
+            return new HttpException(HttpCodes::HTTP_NOT_FOUND, $e->getMessage(), $e);
         } elseif ($e instanceof SlackException) {
             if ($e instanceof SlackTokenException) {
                 return new HttpException(HttpCodes::HTTP_BAD_REQUEST, $e->getMessage(), $e);

--- a/app/Http/Controllers/ConfigController.php
+++ b/app/Http/Controllers/ConfigController.php
@@ -35,7 +35,7 @@ class ConfigController extends Controller
     public function show(Request $request, string $siriusId)
     {
         return response()->json(
-            Config::where('sirius_id', '=', $siriusId)->with('httpPlugins')->firstOrFail(),
+            Config::where('sirius_id', '=', $siriusId)->with('httpExtensions')->firstOrFail(),
             HttpCodes::HTTP_OK
         );
     }
@@ -43,12 +43,12 @@ class ConfigController extends Controller
     public function store(Request $request)
     {
         $token = $request->input('slack_token');
-        $configConfig = $request->input('config');
+        $extensions = $request->input('extensions');
 
         $config = Config::where('slack_token', '=' , $token)->first();
 
         if ($config !== null) {
-            $config->config = $configConfig;
+            $config->extensions = $extensions;
             $config->save();
 
             $this->notifier->update($config);
@@ -61,7 +61,7 @@ class ConfigController extends Controller
             if ($config !== null) {
                 $oldToken = $config->slack_token;
                 $config->slack_token = $token;
-                $config->config = $configConfig;
+                $config->extensions = $extensions;
                 $config->save();
 
                 $this->notifier->delete($oldToken);
@@ -70,7 +70,7 @@ class ConfigController extends Controller
                 $config = new Config;
                 $config->slack_token = $token;
                 $config->slack_ids = $id;
-                $config->config = $configConfig;
+                $config->extensions = $extensions;
                 $config->save();
 
                 $this->notifier->new($config);

--- a/app/Http/Controllers/ExtensionController.php
+++ b/app/Http/Controllers/ExtensionController.php
@@ -9,14 +9,14 @@ use Illuminate\Http\Request;
 use Kayex\HttpCodes;
 
 // Models
-use App\Models\Plugin;
+use App\Models\Extension;
 
-class PluginController extends Controller
+class ExtensionController extends Controller
 {
     public function index(Request $request)
     {
         return response()->json(
-            Plugin::all(),
+            Extension::all(),
             HttpCodes::HTTP_OK
         );
     }

--- a/app/Http/Controllers/HttpExtensionController.php
+++ b/app/Http/Controllers/HttpExtensionController.php
@@ -9,9 +9,9 @@ use Illuminate\Http\Request;
 use Kayex\HttpCodes;
 
 // Models
-use App\Models\HttpPlugin;
+use App\Models\HttpExtension;
 
-class HttpPluginController extends Controller
+class HttpExtensionController extends Controller
 {
     public function store(Request $request)
     {	
@@ -21,37 +21,39 @@ class HttpPluginController extends Controller
     		return response()->json(['ok'=>false], HttpCodes::HTTP_UNAUTHORIZED);
     	}
 
-    	$plugin = new HttpPlugin;
-    	$plugin->sirius_id = $input['sirius_id'];
-    	$plugin->fill($input);
-    	$plugin->save();
+    	$extension = new HttpExtension;
+    	$extension->sirius_id = $input['sirius_id'];
+    	$extension->fill($input);
+    	$extension->save();
         
-        return response()->json($plugin->fresh(), HttpCodes::HTTP_OK);
+        return response()->json($extension->fresh(), HttpCodes::HTTP_OK);
     }
 
-    public function update(Request $request, $id){
+    public function update(Request $request, $id)
+    {
 		$input = $request->all();
 
 		if(!isset($input['sirius_id']) || strlen($input['sirius_id']) !== 64){
 			return response()->json(['ok'=>false], HttpCodes::HTTP_UNAUTHORIZED);
 		}
 
-		$plugin = HttpPlugin::where('sirius_id', '=', $input['sirius_id'])->findOrFail($id);
-		$plugin->fill($input);
-		$plugin->save();
+		$extension = HttpExtension::where('sirius_id', '=', $input['sirius_id'])->findOrFail($id);
+		$extension->fill($input);
+		$extension->save();
 
-		return response()->json($plugin, HttpCodes::HTTP_OK);
+		return response()->json($extension, HttpCodes::HTTP_OK);
 	}
 
-	public function delete(Request $request, $id){
+	public function delete(Request $request, $id)
+    {
 		$input = $request->all();
 
 		if(!isset($input['sirius_id']) || strlen($input['sirius_id']) !== 64){
 			return response()->json(['ok'=>false], HttpCodes::HTTP_UNAUTHORIZED);
 		}
 
-		$plugin = HttpPlugin::where('sirius_id', '=', $input['sirius_id'])->findOrFail($id);
-		$plugin->delete();
+		$extension = HttpExtension::where('sirius_id', '=', $input['sirius_id'])->findOrFail($id);
+		$extension->delete();
 
 		return response()->json(['ok'=>true], HttpCodes::HTTP_OK);
 	}

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -8,20 +8,20 @@ class Config extends Model
     protected $fillable = ['config', 'slack_token', 'http_extensions'];
     protected $hidden = ['slack_ids', 'id'];
     protected $casts = [
-        'config' => 'object',
+        'extensions' => 'object',
         'http_extensions' => 'object',
     ];
 
-    public function httpPlugins()
+    public function httpExtensions()
     {
-        return $this->hasMany(HttpPlugin::class, 'sirius_id', 'sirius_id');
+        return $this->hasMany(HttpExtension::class, 'sirius_id', 'sirius_id');
     }
 
-    public function setConfigAttribute(array $config)
+    public function setExtensionsAttribute(array $config)
     {
         $encoded = json_encode($this->emptyArraysToObjects($config), false);
 
-        $this->attributes['config'] = $encoded;
+        $this->attributes['extensions'] = $encoded;
     }
 
     public function setHttpExtensionsAttribute(array $config)

--- a/app/Models/Extension.php
+++ b/app/Models/Extension.php
@@ -3,7 +3,7 @@
 // Core
 use Illuminate\Database\Eloquent\Model;
 
-class Plugin extends Model
+class Extension extends Model
 {
     public function getConfigAttribute($value)
     {

--- a/app/Models/HttpExtension.php
+++ b/app/Models/HttpExtension.php
@@ -1,6 +1,6 @@
 <?php namespace App\Models;
 
-class HttpPlugin extends Plugin
+class HttpExtension extends Extension
 {	
 	protected $fillable = ['url', 'name', 'description', 'config'];
 	

--- a/database/migrations/2017_03_09_125109_rename_config_column.php
+++ b/database/migrations/2017_03_09_125109_rename_config_column.php
@@ -1,0 +1,71 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameConfigColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Using $table->change() won't work here, as the Doctrine DBAL
+        // that is responsible for modifying columns cannot detect
+        // the database type automatically, and therefore refuses to touch
+        // columns of the 'json' type.
+        //
+        // We'll work around this by dropping the column and adding it again
+        // with the proper default value.
+
+        // Make sure we don't lose any extensions
+        $configs = DB::table('configs')->select('id', 'config')->get();
+
+        Schema::table('configs', function (Blueprint $table) {
+            $table->dropColumn('config');
+        });
+
+        Schema::table('configs', function (Blueprint $table) {
+            $table->json('extensions')->default('{}');
+        });
+
+        foreach ($configs as $config) {
+            $config->extensions = $config->config;
+
+            if ($config->config === '[]') {
+                $config->extensions = '{}';
+            }
+
+            DB::table('configs')->where('id', $config->id)->update([
+                'extensions' => $config->extensions,
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $configs = DB::table('configs')->select('id', 'extensions')->get();
+
+        Schema::table('configs', function (Blueprint $table) {
+            $table->dropColumn('extensions');
+        });
+
+        Schema::table('configs', function (Blueprint $table) {
+            $table->json('config')->default('{}');
+        });
+
+        foreach ($configs as $config) {
+            DB::table('configs')->where('id', $config->id)->update([
+                'config' => $config->extensions,
+            ]);
+        }
+    }
+}

--- a/database/migrations/2017_03_09_125109_rename_config_column.php
+++ b/database/migrations/2017_03_09_125109_rename_config_column.php
@@ -19,7 +19,7 @@ class RenameConfigColumn extends Migration
         // columns of the 'json' type.
         //
         // We'll work around this by dropping the column and adding it again
-        // with the proper default value.
+        // with the correct name.
 
         // Make sure we don't lose any extensions
         $configs = DB::table('configs')->select('id', 'config')->get();

--- a/database/migrations/2017_03_09_125708_rename_http_plugins_table.php
+++ b/database/migrations/2017_03_09_125708_rename_http_plugins_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameHttpPluginsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename('http_plugins', 'http_extensions');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename('http_extensions', 'http_plugins');
+    }
+}

--- a/database/migrations/2017_03_09_125708_rename_plugins_table.php
+++ b/database/migrations/2017_03_09_125708_rename_plugins_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+
+class RenamePluginsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename('plugins', 'extensions');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename('extensions', 'plugins');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,7 +13,6 @@
 
 Route::get('/up', 'UpController@up');
 
-Route::post('/extension', 'ExtensionController@extension');
 Route::get('/plugins', 'ExtensionController@index');
 
 Route::post('/http_plugins', 'HttpPluginController@store');

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,7 +13,8 @@
 
 Route::get('/up', 'UpController@up');
 
-Route::get('/plugins', 'PluginController@index');
+Route::post('/extension', 'ExtensionController@extension');
+Route::get('/plugins', 'ExtensionController@index');
 
 Route::post('/http_plugins', 'HttpPluginController@store');
 Route::put('/http_plugins/{plugin_id}', 'HttpPluginController@update');


### PR DESCRIPTION
This renames all occurrences of `Plugin` to `Extension`, including DB tables/columns.

The API routes have been left unchanged for compatibility reasons. These should be changed at a later time.